### PR TITLE
Bump upper bounds to build on GHC 9.6

### DIFF
--- a/diagrams-gi-cairo.cabal
+++ b/diagrams-gi-cairo.cabal
@@ -38,7 +38,7 @@ License:             BSD3
 License-file:        LICENSE
 Author:              Brent Yorgey
 Maintainer:          diagrams-discuss@googlegroups.com
-Bug-reports:         http://github.com/diagrams/diagrams-cairo/issues
+Bug-reports:         http://github.com/diagrams/diagrams-gi-cairo/issues
 Category:            Graphics
 Build-type:          Simple
 Cabal-version:       >=1.10
@@ -46,7 +46,7 @@ Extra-source-files:  CHANGELOG.md, README.markdown
 Tested-with:         GHC ==8.10.7 || ==9.0.2 || ==9.2.4 || ==9.4.2
 Source-repository head
   type:     git
-  location: http://github.com/diagrams/diagrams-cairo.git
+  location: http://github.com/diagrams/diagrams-gi-cairo.git
 
 Library
   Exposed-modules:     Diagrams.Backend.Cairo
@@ -56,7 +56,7 @@ Library
                        Diagrams.Backend.Cairo.Ptr
                        Diagrams.Backend.Cairo.Text
   Hs-source-dirs:      src
-  Build-depends:       base >= 4.14 && < 4.18,
+  Build-depends:       base >= 4.14 && < 4.19,
                        text,
                        mtl,
                        filepath,


### PR DESCRIPTION
Confirmed to build with `allow-newer`.